### PR TITLE
BAH-1638 Upgrade OMRS version from 2.1.0 to 2.4.2 in Audit log Module

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -51,7 +51,13 @@
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito2</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/api/src/test/java/org/openmrs/module/auditlog/model/AuditLogTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlog/model/AuditLogTest.java
@@ -9,6 +9,7 @@ import org.openmrs.PatientIdentifier;
 import org.openmrs.User;
 import org.openmrs.module.auditlog.util.DateUtil;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Date;
@@ -17,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 public class AuditLogTest {
     @Mock

--- a/api/src/test/java/org/openmrs/module/auditlog/service/impl/AuditLogServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlog/service/impl/AuditLogServiceImplTest.java
@@ -20,6 +20,7 @@ import org.openmrs.module.auditlog.dao.impl.AuditLogDaoImpl;
 import org.openmrs.module.auditlog.model.AuditLog;
 import org.openmrs.module.auditlog.util.DateUtil;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Context.class)
 public class AuditLogServiceImplTest {
@@ -130,7 +132,7 @@ public class AuditLogServiceImplTest {
         AuditLogPayload log = new AuditLogPayload(patientUuid, "message", "eventType", "registration");
         mockStatic(Context.class);
         User user = new User();
-        user.setName("auditlogger");
+        user.setUsername("auditlogger");
         when(Context.getAuthenticatedUser()).thenReturn(user);
         when(Context.getPatientService()).thenReturn(patientService);
         Patient patient = new Patient();
@@ -153,7 +155,7 @@ public class AuditLogServiceImplTest {
         String patientUuid = "patientUuid";
         mockStatic(Context.class);
         User user = new User();
-        user.setName("auditlogger");
+        user.setUsername("auditlogger");
         when(Context.getAuthenticatedUser()).thenReturn(user);
         when(Context.getPatientService()).thenReturn(patientService);
         Patient patient = new Patient();
@@ -178,7 +180,7 @@ public class AuditLogServiceImplTest {
         String patientUuid = "patientUuid";
         mockStatic(Context.class);
         User user = new User();
-        user.setName("auditlogger");
+        user.setUsername("auditlogger");
         when(Context.getAuthenticatedUser()).thenReturn(user);
         when(Context.getPatientService()).thenReturn(patientService);
         Patient patient = new Patient();

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -81,6 +81,11 @@
 			<type>test-jar</type>
 		</dependency>
 
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/omod/src/test/java/org/openmrs/module/auditlog/web/BaseWebControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlog/web/BaseWebControllerTest.java
@@ -10,8 +10,8 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.HandlerExecutionChain;
-import org.springframework.web.servlet.mvc.annotation.AnnotationMethodHandlerAdapter;
-import org.springframework.web.servlet.mvc.annotation.DefaultAnnotationHandlerMapping;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -22,10 +22,10 @@ import java.util.Map;
 public class BaseWebControllerTest extends BaseModuleWebContextSensitiveTest {
 
     @Autowired
-    private AnnotationMethodHandlerAdapter handlerAdapter;
+    private RequestMappingHandlerAdapter handlerAdapter;
 
     @Autowired
-    private List<DefaultAnnotationHandlerMapping> handlerMappings;
+    private List<RequestMappingHandlerMapping> handlerMappings;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -124,7 +124,7 @@ public class BaseWebControllerTest extends BaseModuleWebContextSensitiveTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         HandlerExecutionChain handlerExecutionChain = null;
-        for (DefaultAnnotationHandlerMapping handlerMapping : handlerMappings) {
+        for (RequestMappingHandlerMapping handlerMapping : handlerMappings) {
             handlerExecutionChain = handlerMapping.getHandler(request);
             if (handlerExecutionChain != null) {
                 break;

--- a/omod/src/test/java/org/openmrs/module/auditlog/web/controller/AuditLogControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlog/web/controller/AuditLogControllerTest.java
@@ -16,6 +16,7 @@ import org.openmrs.module.auditlog.service.AuditLogService;
 import org.openmrs.module.auditlog.util.DateUtil;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+@PowerMockIgnore("javax.management.*")
 @PrepareForTest({Context.class})
 @RunWith(PowerMockRunner.class)
 public class AuditLogControllerTest {

--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,12 @@
 	</build>
 
     <properties>
-        <openmrs.platform.version>2.1.0</openmrs.platform.version>
+        <openmrs.platform.version>2.4.2</openmrs.platform.version>
 		<!--test dependencies-->
-		<junitVersion>4.12</junitVersion>
-		<powerMockVersion>1.6.5</powerMockVersion>
-		<hamcrestVersion>1.3</hamcrestVersion>
-		<mockitoVersion>1.10.19</mockitoVersion>
+		<junitVersion>4.13</junitVersion>
+		<powerMockVersion>2.0.7</powerMockVersion>
+		<hamcrestVersion>2.2</hamcrestVersion>
+		<mockitoVersion>3.5.11</mockitoVersion>
 		<reportingModuleVersion>0.10.4</reportingModuleVersion>
 		<calculationModuleVersion>1.3-SNAPSHOT</calculationModuleVersion>
 		<serializationXstreamModuleVersion>0.2.12</serializationXstreamModuleVersion>
@@ -138,7 +138,7 @@
 
 			<dependency>
 				<groupId>org.powermock</groupId>
-				<artifactId>powermock-api-mockito</artifactId>
+				<artifactId>powermock-api-mockito2</artifactId>
 				<version>${powerMockVersion}</version>
 				<scope>test</scope>
 			</dependency>
@@ -206,18 +206,6 @@
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest-all</artifactId>
 				<version>${hamcrestVersion}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.mockito</groupId>
-				<artifactId>mockito-all</artifactId>
-				<version>${mockitoVersion}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>org.hamcrest</groupId>
-						<artifactId>hamcrest-core</artifactId>
-					</exclusion>
-				</exclusions>
 				<scope>test</scope>
 			</dependency>
 


### PR DESCRIPTION
## Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1638
Upgraded openMRSVersion to 2.4.2

## Solution
Add missing dependencies that have been generated due to version upgrade.
Modify test cases, test data if needed

### The following changes have been made:

#### Udpated

- openMRS v2.1.0 -> 2.4.2
- junitVersion v4.12 -> 4.13
- powerMockVersion v1.6.5 -> 2.0.7
- hamcrestVersion v1.3 -> 2.2
- mockitoVersion v1.10.19 ->3.5.11

- updated dependency artifactId powermock-api-mockito to powermock-api-mockito2

#### Added

- added import for RequestMappingHandlerMapping, RequestMappingHandlerAdapter classes
- added PowerMockIgnore("javax.management.*") to resolve classloader conflicts

#### Removed
- removed mockito-all dependency, since mockito-core covers these dependencies in the updated version 
- removed import and usage for Deprecated classes AnnotationMethodHandlerAdapter, DefaultAnnotationHandlerMapping 

### Testing
The screenshots for successful compilation have been added on the ticket.
