### PR TITLE
BAH-1850 Upgrade OMRS version from 2.4.2 to 2.5.0 in Audit log Module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 	</build>
 
     <properties>
-        <openmrs.platform.version>2.4.2</openmrs.platform.version>
+        <openmrs.platform.version>2.5.0</openmrs.platform.version>
 		<!--test dependencies-->
 		<junitVersion>4.13</junitVersion>
 		<powerMockVersion>2.0.7</powerMockVersion>


### PR DESCRIPTION
### Summary:

This is a story. https://bahmni.atlassian.net/browse/BAH-1850
Upgraded openMRSVersion to 2.5.0

### Solution
Add missing dependencies that have been generated due to version upgrade.

## The following changes have been made:

- udpated
openMRS v2.4.2 -> 2.5.0


### Testing
The screenshots for successful compilation have been added on the ticket.